### PR TITLE
fix(WP-38): устранены 7 ошибок официального Plugin Check

### DIFF
--- a/includes/admin/class-wp-apiship-admin.php
+++ b/includes/admin/class-wp-apiship-admin.php
@@ -373,7 +373,7 @@ if ( ! class_exists('ApiShip_Admin') ) :
 			$this->labels_log_file = Options\ApiShip_Options::get_labels_file();
 			
 			if ( file_exists($this->labels_log_file) ) {
-				unlink( $this->labels_log_file );
+				wp_delete_file( $this->labels_log_file );
 			}
 		}
 

--- a/includes/admin/templates/docs-form.php
+++ b/includes/admin/templates/docs-form.php
@@ -22,9 +22,7 @@ $message = array();
 
 if ( file_exists( $labels_file ) ) {
 	
-	$handle = fopen($labels_file, "r");
-	$data = fread($handle, filesize($labels_file));
-	fclose($handle);
+	$data = file_get_contents( $labels_file ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents -- локальный файл журнала плагина.
 
 	$data = json_decode($data);
 
@@ -41,7 +39,7 @@ if ( file_exists( $labels_file ) ) {
 		if ( $response->response->code == HTTP\ApiShip_HTTP::OK ) {
 
 			if ( $timestamp ) {
-				$message[] = esc_html__('Дата получения наклеек: ', 'apiship') . esc_html( date( 'd.m.Y', $timestamp ) );
+				$message[] = esc_html__('Дата получения наклеек: ', 'apiship') . esc_html( gmdate( 'd.m.Y', $timestamp ) );
 				$message[] = '<br />';
 			}
 			

--- a/includes/class-wp-apiship-cron.php
+++ b/includes/class-wp-apiship-cron.php
@@ -87,7 +87,7 @@ if (!class_exists('ApiShip_Cron')) :
 			set_time_limit(300);
 
 			$now = time();
-			$query_date = date('Y-m-d\TH:i:s', $this->last_query) . $this->timezone;
+			$query_date = gmdate('Y-m-d\TH:i:s', $this->last_query) . $this->timezone;
 
 			$this->log("Дата: $query_date");
 

--- a/includes/class-wp-apiship-hpos-migration.php
+++ b/includes/class-wp-apiship-hpos-migration.php
@@ -356,7 +356,7 @@ if ( ! class_exists( __NAMESPACE__ . '\ApiShip_HPOS_Migration' ) ) :
 			
 			return array(
 				'completed' => (bool) $completed,
-				'completed_at' => $completed ? date( 'Y-m-d H:i:s', $completed ) : null,
+				'completed_at' => $completed ? gmdate( 'Y-m-d H:i:s', $completed ) : null,
 				'hpos_enabled' => ApiShip_HPOS_Compatibility::is_hpos_enabled(),
 			);
 		}


### PR DESCRIPTION
Доводка релиза 1.8.0 до нуля ошибок официального Plugin Check (PCP): date()→gmdate() (эквивалентно в рантайме WP), unlink()→wp_delete_file(), fopen/fread/fclose→file_get_contents. Найдено при верификации релизного архива в чистом WP 7.0.2 + WC 10.9.4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)